### PR TITLE
use SourceLink 2.1

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="sourcelink" value="https://ci.appveyor.com/nuget/sourcelink/" />
+  </packageSources>
+</configuration>

--- a/crypto/src/crypto.csproj
+++ b/crypto/src/crypto.csproj
@@ -32,8 +32,8 @@
     <None Include="..\..\BouncyCastle.snk" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.0-rc4-31" PrivateAssets="All" />
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.0.2" PrivateAssets="All" /> 
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.0.2" />
+    <PackageReference Include="SourceLink.Create.GitHub" Version="[2.0.2-b434]" PrivateAssets="All" /> 
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="[2.0.2-b434]" />
   </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/crypto/src/crypto.csproj
+++ b/crypto/src/crypto.csproj
@@ -32,8 +32,8 @@
     <None Include="..\..\BouncyCastle.snk" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.0-rc4-31" PrivateAssets="All" />
-    <PackageReference Include="SourceLink.Create.GitHub" Version="[2.0.2-b434]" PrivateAssets="All" /> 
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="[2.0.2-b434]" />
+    <PackageReference Include="SourceLink.Create.GitHub" Version="[2.1.0-b435]" PrivateAssets="All" /> 
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="[2.1.0-b435]" />
   </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/crypto/src/crypto.csproj
+++ b/crypto/src/crypto.csproj
@@ -32,8 +32,8 @@
     <None Include="..\..\BouncyCastle.snk" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" />
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.0-rc4-31" PrivateAssets="All" />
-    <PackageReference Include="SourceLink.Create.GitHub" Version="[2.1.0-b435]" PrivateAssets="All" /> 
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="[2.1.0-b435]" />
+    <PackageReference Include="SourceLink.Create.GitHub" Version="[2.1.0-b436]" PrivateAssets="All" /> 
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="[2.1.0-b436]" />
   </ItemGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>


### PR DESCRIPTION
Fix for https://github.com/ctaggart/SourceLink/issues/175
It worked for me: https://ci.appveyor.com/project/ctaggart/bc-csharp/build/1.8.2-sourcelink.1+33.build.3
When I release a 2.1 to NuGet, you can remove the NuGet.Config and update accordingly.